### PR TITLE
refactor(api): extract all backend API URLs to src/config/api.ts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,2 @@
 NEXT_PUBLIC_APP_ENV=development
+NEXT_PUBLIC_API_URL=https://vibetel-backend.duckdns.org

--- a/src/app/ar/page.tsx
+++ b/src/app/ar/page.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import Webcam from 'react-webcam'
 import Tile from '@/components/ui/Tile'
+import { API_ENDPOINTS } from '@/config/api'
 
 type Detection = {
   bbox?: [number, number, number, number]
@@ -59,7 +60,7 @@ export default function ARPage() {
     form.append('file', file)
     try {
       setProcessing(true)
-      const r = await fetch('https://vibe-tel.ddns.net/process-image', {
+      const r = await fetch(API_ENDPOINTS.processImage, {
         method: 'POST',
         body: form,
       })

--- a/src/app/explore/page.tsx
+++ b/src/app/explore/page.tsx
@@ -6,6 +6,7 @@ import Tile from '@/components/ui/Tile'
 import { Loader2, Volume2, Sparkles, ArrowLeft } from 'lucide-react'
 import Link from 'next/link'
 import { useExploreStore } from '@/stores/exploreStore'
+import { API_ENDPOINTS } from '@/config/api'
 
 type Detection = {
   bbox?: [number, number, number, number]
@@ -226,7 +227,7 @@ export default function ExplorePage() {
     let aborted = false
     const fetchTT = async (ru: string) => {
       try {
-        const r = await fetch('https://vibe-tel.ddns.net/translate', {
+        const r = await fetch(API_ENDPOINTS.translate, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
@@ -266,7 +267,7 @@ export default function ExplorePage() {
     let aborted = false
     const fetchTT = async (ru: string) => {
       try {
-        const r = await fetch('https://vibe-tel.ddns.net/translate', {
+        const r = await fetch(API_ENDPOINTS.translate, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
@@ -319,7 +320,7 @@ export default function ExplorePage() {
       try {
         if (!text || isSpeaking) return
         setIsSpeaking(true)
-        const r = await fetch('https://vibe-tel.ddns.net/audio', {
+        const r = await fetch(API_ENDPOINTS.audio, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ text }),
@@ -415,7 +416,7 @@ export default function ExplorePage() {
         setError('')
         const form = new FormData()
         form.append('file', file)
-        const r = await fetch('https://vibe-tel.ddns.net/extract-objects', {
+        const r = await fetch(API_ENDPOINTS.extractObjects, {
           method: 'POST',
           body: form,
         })
@@ -495,7 +496,7 @@ export default function ExplorePage() {
       setIsGenerating(true)
       // 1-запрос: билингвальная генерация (RU + TT)
       const r = await fetch(
-        'https://vibe-tel.ddns.net/generate-sentence-bilingual',
+        API_ENDPOINTS.generateSentenceBilingual,
         {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },

--- a/src/app/learn/cards/page.tsx
+++ b/src/app/learn/cards/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import BackToLearn from '@/components/ui/BackToLearn'
 import { Volume2, Shuffle, ChevronLeft, ChevronRight } from 'lucide-react'
+import { API_ENDPOINTS } from '@/config/api'
 
 type Card = { ru: string; tt: string }
 
@@ -33,7 +34,7 @@ export default function CardsPage() {
     if (!text || isSpeaking) return
     try {
       setIsSpeaking(true)
-      const r = await fetch('https://vibe-tel.ddns.net/audio', {
+      const r = await fetch(API_ENDPOINTS.audio, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ text }),

--- a/src/app/learn/vocab/page.tsx
+++ b/src/app/learn/vocab/page.tsx
@@ -6,6 +6,7 @@ import { markAchievement } from '@/lib/records'
 import { BookOpen, Sparkles, Shuffle, X, Loader2, Check } from 'lucide-react'
 import Tile from '@/components/ui/Tile'
 import { Volume2, Copy, Star, StarOff } from 'lucide-react'
+import { API_ENDPOINTS } from '@/config/api'
 
 export default function VocabPage() {
   const [ruWords, setRuWords] = useState<string[]>([])
@@ -67,7 +68,7 @@ export default function VocabPage() {
     let cancelled = false
     const fetchMissing = async (ru: string) => {
       try {
-        const r = await fetch('https://vibe-tel.ddns.net/translate', {
+        const r = await fetch(API_ENDPOINTS.translate, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
@@ -115,7 +116,7 @@ export default function VocabPage() {
     try {
       if (!text || isSpeaking) return
       setIsSpeaking(true)
-      const r = await fetch('https://vibe-tel.ddns.net/audio', {
+      const r = await fetch(API_ENDPOINTS.audio, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ text }),
@@ -151,7 +152,7 @@ export default function VocabPage() {
     try {
       setIsGenerating(true)
       const r = await fetch(
-        'https://vibe-tel.ddns.net/generate-sentence-bilingual',
+        API_ENDPOINTS.generateSentenceBilingual,
         {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },

--- a/src/app/scan/page.tsx
+++ b/src/app/scan/page.tsx
@@ -4,6 +4,7 @@ import { useState, useRef } from 'react'
 import Tile from '@/components/ui/Tile'
 import { Camera, Upload, Loader2 } from 'lucide-react'
 import Image from 'next/image'
+import { API_ENDPOINTS } from '@/config/api'
 
 type ProcessImageResponse = {
   objects_ru: string[]
@@ -40,7 +41,7 @@ export default function ScanPage() {
       setLoading(true)
       const formData = new FormData()
       formData.append('file', file)
-      const res = await fetch('https://vibe-tel.ddns.net/process-image', {
+      const res = await fetch(API_ENDPOINTS.processImage, {
         method: 'POST',
         body: formData,
       })

--- a/src/components/dashboard/RecentWords.tsx
+++ b/src/components/dashboard/RecentWords.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react'
 import Tile from '@/components/ui/Tile'
+import { API_ENDPOINTS } from '@/config/api'
 
 export function RecentWords() {
   const [words, setWords] = useState<string[]>([])
@@ -40,7 +41,7 @@ export function RecentWords() {
       const missing = words.filter((ru) => !ruToTt[ru]).slice(0, 8)
       for (const ru of missing) {
         try {
-          const r = await fetch('https://vibe-tel.ddns.net/translate', {
+          const r = await fetch(API_ENDPOINTS.translate, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({

--- a/src/components/gallery/ImageDetail.tsx
+++ b/src/components/gallery/ImageDetail.tsx
@@ -17,6 +17,7 @@ import 'react-tooltip/dist/react-tooltip.css'
 import { Album } from '@/types/gallery'
 import { useIsAndroid } from '@/hooks/useIsAndroid'
 import { loadRuToTtMap } from '@/lib/words'
+import { API_ENDPOINTS } from '@/config/api'
 
 interface ImageDetailProps {
   data: Album
@@ -179,7 +180,7 @@ export const ImageDetail = ({ data, onClose }: ImageDetailProps) => {
     try {
       setGenLoading(true)
       setGenError(null)
-      const r = await fetch('https://vibe-tel.ddns.net/generate-album-memory', {
+      const r = await fetch(API_ENDPOINTS.generateAlbumMemory, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ objects, album_theme: data.title }),
@@ -215,7 +216,7 @@ export const ImageDetail = ({ data, onClose }: ImageDetailProps) => {
     if (!text || isSpeaking) return
     try {
       setIsSpeaking(true)
-      const r = await fetch('https://vibe-tel.ddns.net/audio', {
+      const r = await fetch(API_ENDPOINTS.audio, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ text }),
@@ -247,7 +248,7 @@ export const ImageDetail = ({ data, onClose }: ImageDetailProps) => {
     else translation = maps.ttToRu[trimmed] || ''
     if (!translation) {
       try {
-        const r = await fetch('https://vibe-tel.ddns.net/translate', {
+        const r = await fetch(API_ENDPOINTS.translate, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({

--- a/src/config/api.ts
+++ b/src/config/api.ts
@@ -1,0 +1,12 @@
+export const API_BASE_URL = (
+  process.env.NEXT_PUBLIC_API_URL || 'https://vibetel-backend.duckdns.org'
+).replace(/\/+$/, '')
+
+export const API_ENDPOINTS = {
+  audio: `${API_BASE_URL}/audio`,
+  translate: `${API_BASE_URL}/translate`,
+  processImage: `${API_BASE_URL}/process-image`,
+  extractObjects: `${API_BASE_URL}/extract-objects`,
+  generateSentenceBilingual: `${API_BASE_URL}/generate-sentence-bilingual`,
+  generateAlbumMemory: `${API_BASE_URL}/generate-album-memory`,
+} as const


### PR DESCRIPTION
- Add API_BASE_URL and API_ENDPOINTS constants in src/config/api.ts
- Default backend: https://vibetel-backend.duckdns.org (via NEXT_PUBLIC_API_URL env)
- Update fetch calls in learn/cards, learn/vocab, scan, explore, ar pages
- Update ImageDetail.tsx and RecentWords.tsx components
- Add NEXT_PUBLIC_API_URL to .env.example